### PR TITLE
Add mark command

### DIFF
--- a/src/main/java/werkbook/task/logic/commands/AddCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/AddCommand.java
@@ -1,6 +1,6 @@
 package werkbook.task.logic.commands;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import werkbook.task.commons.exceptions.IllegalValueException;
@@ -41,7 +41,10 @@ public class AddCommand extends Command {
      */
     public AddCommand(String name, String description, String startDateTime, String endDateTime, Set<String> tags)
             throws IllegalValueException {
-        final Set<Tag> tagSet = new HashSet<>();
+        final Set<Tag> tagSet = new LinkedHashSet<>();
+
+        // Starts with default "Incomplete" tag, followed by the rest that are specified
+        tagSet.add(new Tag("Incomplete"));
         for (String tagName : tags) {
             tagSet.add(new Tag(tagName));
         }

--- a/src/main/java/werkbook/task/logic/commands/EditCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/EditCommand.java
@@ -80,6 +80,7 @@ public class EditCommand extends Command {
     /**
      * Creates and returns a {@code Task} with the details of {@code taskToEdit}
      * edited with {@code editTaskDescriptor}.
+     *
      * @throws IllegalValueException
      */
     private static Task createEditedTask(ReadOnlyTask taskToEdit, EditTaskDescriptor editTaskDescriptor)
@@ -95,14 +96,15 @@ public class EditCommand extends Command {
                 .orElseGet(taskToEdit::getEndDateTime);
         // Must make it not override first tag
         taskToEdit.getTags().mergeFromFirst(editTaskDescriptor.getTags());
+        UniqueTagList updatedTags = new UniqueTagList(taskToEdit.getTags());
 
         return new Task(updatedName, updatedDescription, updatedStartDateTime, updatedEndDateTime,
-                taskToEdit.getTags());
+                updatedTags);
     }
 
     /**
-     * Stores the details to edit the task with. Each non-empty field value
-     * will replace the corresponding field value of the task.
+     * Stores the details to edit the task with. Each non-empty field value will
+     * replace the corresponding field value of the task.
      */
     public static class EditTaskDescriptor {
         private Optional<Name> name = Optional.empty();

--- a/src/main/java/werkbook/task/logic/commands/EditCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/EditCommand.java
@@ -93,10 +93,11 @@ public class EditCommand extends Command {
                 .orElseGet(taskToEdit::getStartDateTime);
         EndDateTime updatedEndDateTime = editTaskDescriptor.getEndDateTime()
                 .orElseGet(taskToEdit::getEndDateTime);
-        UniqueTagList updatedTags = editTaskDescriptor.getTags().orElseGet(taskToEdit::getTags);
+        // Must make it not override first tag
+        taskToEdit.getTags().mergeFromFirst(editTaskDescriptor.getTags());
 
         return new Task(updatedName, updatedDescription, updatedStartDateTime, updatedEndDateTime,
-                updatedTags);
+                taskToEdit.getTags());
     }
 
     /**

--- a/src/main/java/werkbook/task/logic/commands/MarkCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/MarkCommand.java
@@ -1,0 +1,134 @@
+package werkbook.task.logic.commands;
+
+import java.util.List;
+import java.util.Optional;
+
+import werkbook.task.commons.core.Messages;
+import werkbook.task.commons.exceptions.IllegalValueException;
+import werkbook.task.commons.util.CollectionUtil;
+import werkbook.task.logic.commands.exceptions.CommandException;
+import werkbook.task.model.tag.UniqueTagList;
+import werkbook.task.model.task.ReadOnlyTask;
+import werkbook.task.model.task.Task;
+import werkbook.task.model.task.UniqueTaskList;
+
+/**
+ * Marks an existing task in the task list as done.
+ */
+public class MarkCommand extends Command {
+
+    public static final String COMMAND_WORD = "mark";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Marks an existing task in task list as done "
+            + "by the index number used in the last task listing. "
+            + "Parameters: INDEX (must be a positive integer)" + "Example: " + COMMAND_WORD + " mark 1";
+
+    public static final String MESSAGE_MARK_TASK_SUCCESS = "%1$s marked as complete!";
+    public static final String MESSAGE_TASK_ALREADY_COMPLETE = "This task is already complete";
+    public static final String MESSAGE_TASK_NOT_FOUND = "This task cannot be found";
+
+    private final int targetIndex;
+    private final MarkTaskDescriptor markTaskDescriptor;
+
+    /**
+     * @param targetIndex the index of the task in the filtered task list to
+     *            edit
+     * @param markTaskDescriptor details to edit the task with
+     */
+    public MarkCommand(int targetIndex, MarkTaskDescriptor markTaskDescriptor) {
+        assert targetIndex > 0;
+        assert markTaskDescriptor != null;
+
+        // converts targetIndex from one-based to zero-based.
+        this.targetIndex = targetIndex - 1;
+
+        this.markTaskDescriptor = new MarkTaskDescriptor(markTaskDescriptor);
+    }
+
+    @Override
+    public CommandResult execute() throws CommandException {
+        List<ReadOnlyTask> lastShownList = model.getFilteredTaskList();
+
+        if (targetIndex >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+        }
+
+        ReadOnlyTask taskToMark = lastShownList.get(targetIndex);
+        String test = taskToMark.getTags().toSet().toArray()[0].toString().substring(1, 9);
+
+        if (test.equals("Complete")) {
+            System.out.println("This task is complete!");
+            throw new CommandException(MESSAGE_TASK_ALREADY_COMPLETE);
+        } else {
+
+            Task editedTask = createMarkedTask(taskToMark, markTaskDescriptor);
+
+            try {
+                model.updateTask(targetIndex, editedTask);
+            } catch (UniqueTaskList.DuplicateTaskException dpe) {
+                throw new CommandException(MESSAGE_TASK_ALREADY_COMPLETE);
+            }
+            model.updateFilteredListToShowAll();
+            return new CommandResult(String.format(MESSAGE_MARK_TASK_SUCCESS, taskToMark));
+        }
+    }
+
+    /**
+     * Creates and returns a {@code Task} with the details of {@code taskToEdit}
+     * edited with {@code markTaskDescriptor}.
+     */
+    private static Task createMarkedTask(ReadOnlyTask taskToEdit, MarkTaskDescriptor markTaskDescriptor)
+            throws CommandException {
+        assert taskToEdit != null;
+
+        UniqueTagList updatedTags = markTaskDescriptor.getTags().orElseGet(taskToEdit::getTags);
+
+        Task taskToReturn = null;
+
+        try {
+            taskToReturn = new Task(taskToEdit.getName(), taskToEdit.getDescription(), taskToEdit.getStartDateTime(),
+                    taskToEdit.getEndDateTime(), updatedTags);
+        } catch (IllegalValueException e) {
+            // TODO Auto-generated catch block
+            e.printStackTrace();
+        }
+
+        return taskToReturn;
+    }
+
+    /**
+     * Stores the details to edit the task with. Each non-empty field value will
+     * replace the corresponding field value of the task.
+     */
+    public static class MarkTaskDescriptor {
+        private Optional<UniqueTagList> tags = Optional.empty();
+
+        public MarkTaskDescriptor() {
+        }
+
+        public MarkTaskDescriptor(MarkTaskDescriptor toCopy) {
+            this.tags = toCopy.getTags();
+        }
+
+        /**
+         * Returns true if at least one field is edited.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyPresent(this.tags);
+        }
+
+        public void setTags(Optional<UniqueTagList> tags) {
+            assert tags != null;
+            this.tags = tags;
+        }
+
+        public Optional<UniqueTagList> getTags() {
+            return tags;
+        }
+    }
+
+    @Override
+    public boolean isMutable() {
+        return true;
+    }
+}

--- a/src/main/java/werkbook/task/logic/commands/MarkCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/MarkCommand.java
@@ -1,5 +1,8 @@
 package werkbook.task.logic.commands;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -7,6 +10,7 @@ import werkbook.task.commons.core.Messages;
 import werkbook.task.commons.exceptions.IllegalValueException;
 import werkbook.task.commons.util.CollectionUtil;
 import werkbook.task.logic.commands.exceptions.CommandException;
+import werkbook.task.logic.parser.ParserUtil;
 import werkbook.task.model.tag.UniqueTagList;
 import werkbook.task.model.task.ReadOnlyTask;
 import werkbook.task.model.task.Task;
@@ -23,12 +27,12 @@ public class MarkCommand extends Command {
             + "by the index number used in the last task listing. "
             + "Parameters: INDEX (must be a positive integer)" + "Example: " + COMMAND_WORD + " mark 1";
 
-    public static final String MESSAGE_MARK_TASK_SUCCESS = "%1$s marked as complete!";
-    public static final String MESSAGE_TASK_ALREADY_COMPLETE = "This task is already complete";
+    public static final String MESSAGE_MARK_TASK_SUCCESS = "Marked %1$s as complete!";
+    public static final String MESSAGE_UNMARK_TASK_SUCCESS = "Unmark %1$s as complete!";
     public static final String MESSAGE_TASK_NOT_FOUND = "This task cannot be found";
 
     private final int targetIndex;
-    private final MarkTaskDescriptor markTaskDescriptor;
+    private MarkTaskDescriptor markTaskDescriptor;
 
     /**
      * @param targetIndex the index of the task in the filtered task list to
@@ -41,8 +45,6 @@ public class MarkCommand extends Command {
 
         // converts targetIndex from one-based to zero-based.
         this.targetIndex = targetIndex - 1;
-
-        this.markTaskDescriptor = new MarkTaskDescriptor(markTaskDescriptor);
     }
 
     @Override
@@ -53,24 +55,42 @@ public class MarkCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
         }
 
+        // Checks the task's completion status and set to the opposite
         ReadOnlyTask taskToMark = lastShownList.get(targetIndex);
-        String test = taskToMark.getTags().toSet().toArray()[0].toString().substring(1, 9);
+        Object[] tagArray = taskToMark.getTags().toSet().toArray();
 
-        if (test.equals("Complete")) {
-            System.out.println("This task is complete!");
-            throw new CommandException(MESSAGE_TASK_ALREADY_COMPLETE);
-        } else {
+        String taskStatus = tagArray[0].toString().substring(1, 9);
+        taskStatus = taskStatus.equals("Complete") ? "Incomplete" : "Complete";
 
-            Task editedTask = createMarkedTask(taskToMark, markTaskDescriptor);
+        // Create a new list of tags
+        ArrayList<String> newTags = new ArrayList<String>();
+        newTags.add(taskStatus);
 
-            try {
-                model.updateTask(targetIndex, editedTask);
-            } catch (UniqueTaskList.DuplicateTaskException dpe) {
-                throw new CommandException(MESSAGE_TASK_ALREADY_COMPLETE);
-            }
-            model.updateFilteredListToShowAll();
-            return new CommandResult(String.format(MESSAGE_MARK_TASK_SUCCESS, taskToMark));
+        for (int i = 1; i < tagArray.length; i++) {
+            // Remove brackets
+            newTags.add(tagArray[i].toString().substring(1, tagArray[i].toString().length() - 1));
         }
+
+        markTaskDescriptor = new MarkTaskDescriptor();
+        String statusMessage = taskStatus.equals("Complete") ? MESSAGE_MARK_TASK_SUCCESS
+                : MESSAGE_UNMARK_TASK_SUCCESS;
+
+        try {
+            markTaskDescriptor.setTags(parseTagsForEdit(ParserUtil.toSet(Optional.of(newTags))));
+        } catch (IllegalValueException ive) {
+            ive.printStackTrace();
+        }
+
+        Task markedTask = createMarkedTask(taskToMark, markTaskDescriptor);
+
+        try {
+            model.updateTask(targetIndex, markedTask);
+        } catch (UniqueTaskList.DuplicateTaskException dpe) {
+            dpe.printStackTrace();
+        }
+
+        model.updateFilteredListToShowAll();
+        return new CommandResult(String.format(statusMessage, taskToMark.getName()));
     }
 
     /**
@@ -86,8 +106,8 @@ public class MarkCommand extends Command {
         Task taskToReturn = null;
 
         try {
-            taskToReturn = new Task(taskToEdit.getName(), taskToEdit.getDescription(), taskToEdit.getStartDateTime(),
-                    taskToEdit.getEndDateTime(), updatedTags);
+            taskToReturn = new Task(taskToEdit.getName(), taskToEdit.getDescription(),
+                    taskToEdit.getStartDateTime(), taskToEdit.getEndDateTime(), updatedTags);
         } catch (IllegalValueException e) {
             // TODO Auto-generated catch block
             e.printStackTrace();
@@ -130,5 +150,15 @@ public class MarkCommand extends Command {
     @Override
     public boolean isMutable() {
         return true;
+    }
+
+    private Optional<UniqueTagList> parseTagsForEdit(Collection<String> tags) throws IllegalValueException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseTags(tagSet));
     }
 }

--- a/src/main/java/werkbook/task/logic/commands/MarkCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/MarkCommand.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 
 import werkbook.task.commons.core.Messages;
 import werkbook.task.commons.exceptions.IllegalValueException;
-import werkbook.task.commons.util.CollectionUtil;
 import werkbook.task.logic.commands.exceptions.CommandException;
 import werkbook.task.logic.parser.ParserUtil;
 import werkbook.task.model.tag.UniqueTagList;
@@ -133,7 +132,7 @@ public class MarkCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyPresent(this.tags);
+            return true;
         }
 
         public void setTags(Optional<UniqueTagList> tags) {

--- a/src/main/java/werkbook/task/logic/commands/MarkCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/MarkCommand.java
@@ -25,7 +25,7 @@ public class MarkCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Marks an existing task in task list as done "
             + "by the index number used in the last task listing. "
-            + "Parameters: INDEX (must be a positive integer)" + "Example: " + COMMAND_WORD + " mark 1";
+            + "Parameters: INDEX (must be a positive integer)" + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_MARK_TASK_SUCCESS = "Marked %1$s as complete!";
     public static final String MESSAGE_UNMARK_TASK_SUCCESS = "Unmark %1$s as complete!";
@@ -39,7 +39,7 @@ public class MarkCommand extends Command {
      *            edit
      * @param markTaskDescriptor details to edit the task with
      */
-    public MarkCommand(int targetIndex, MarkTaskDescriptor markTaskDescriptor) {
+    public MarkCommand(int targetIndex) {
         assert targetIndex > 0;
         assert markTaskDescriptor != null;
 

--- a/src/main/java/werkbook/task/logic/commands/MarkCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/MarkCommand.java
@@ -41,7 +41,6 @@ public class MarkCommand extends Command {
      */
     public MarkCommand(int targetIndex) {
         assert targetIndex > 0;
-        assert markTaskDescriptor != null;
 
         // converts targetIndex from one-based to zero-based.
         this.targetIndex = targetIndex - 1;

--- a/src/main/java/werkbook/task/logic/parser/MarkCommandParser.java
+++ b/src/main/java/werkbook/task/logic/parser/MarkCommandParser.java
@@ -2,18 +2,11 @@ package werkbook.task.logic.parser;
 
 import static werkbook.task.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.Optional;
 
-import werkbook.task.commons.exceptions.IllegalValueException;
 import werkbook.task.logic.commands.Command;
-import werkbook.task.logic.commands.EditCommand;
 import werkbook.task.logic.commands.IncorrectCommand;
 import werkbook.task.logic.commands.MarkCommand;
-import werkbook.task.logic.commands.MarkCommand.MarkTaskDescriptor;
-import werkbook.task.model.tag.UniqueTagList;
 
 /**
  * Parses input arguments and creates a new MarkCommand object
@@ -31,38 +24,7 @@ public class MarkCommandParser {
             return new IncorrectCommand(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
         }
-        MarkTaskDescriptor markTaskDescriptor = new MarkTaskDescriptor();
-        try {
-            ArrayList<String> newTags = new ArrayList<String>();
-            newTags.add("Complete");
 
-            markTaskDescriptor
-                    .setTags(parseTagsForEdit(ParserUtil.toSet(Optional.of(newTags))));
-        } catch (IllegalValueException ive) {
-            return new IncorrectCommand(ive.getMessage());
-        }
-
-        if (!markTaskDescriptor.isAnyFieldEdited()) {
-            return new IncorrectCommand(EditCommand.MESSAGE_NOT_EDITED);
-        }
-
-        return new MarkCommand(index.get(), markTaskDescriptor);
+        return new MarkCommand(index.get());
     }
-
-    /**
-     * Parses {@code Collection<String> tags} into an
-     * {@code Optional<UniqueTagList>} if {@code tags} is non-empty. If
-     * {@code tags} contain only one element which is an empty string, it will
-     * be parsed into a {@code Optional<UniqueTagList>} containing zero tags.
-     */
-    private Optional<UniqueTagList> parseTagsForEdit(Collection<String> tags) throws IllegalValueException {
-        assert tags != null;
-
-        if (tags.isEmpty()) {
-            return Optional.empty();
-        }
-        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
-        return Optional.of(ParserUtil.parseTags(tagSet));
-    }
-
 }

--- a/src/main/java/werkbook/task/logic/parser/MarkCommandParser.java
+++ b/src/main/java/werkbook/task/logic/parser/MarkCommandParser.java
@@ -31,22 +31,22 @@ public class MarkCommandParser {
             return new IncorrectCommand(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
         }
-        MarkTaskDescriptor editTaskDescriptor = new MarkTaskDescriptor();
+        MarkTaskDescriptor markTaskDescriptor = new MarkTaskDescriptor();
         try {
             ArrayList<String> newTags = new ArrayList<String>();
             newTags.add("Complete");
 
-            editTaskDescriptor
+            markTaskDescriptor
                     .setTags(parseTagsForEdit(ParserUtil.toSet(Optional.of(newTags))));
         } catch (IllegalValueException ive) {
             return new IncorrectCommand(ive.getMessage());
         }
 
-        if (!editTaskDescriptor.isAnyFieldEdited()) {
+        if (!markTaskDescriptor.isAnyFieldEdited()) {
             return new IncorrectCommand(EditCommand.MESSAGE_NOT_EDITED);
         }
 
-        return new MarkCommand(index.get(), editTaskDescriptor);
+        return new MarkCommand(index.get(), markTaskDescriptor);
     }
 
     /**

--- a/src/main/java/werkbook/task/logic/parser/MarkCommandParser.java
+++ b/src/main/java/werkbook/task/logic/parser/MarkCommandParser.java
@@ -1,0 +1,68 @@
+package werkbook.task.logic.parser;
+
+import static werkbook.task.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+
+import werkbook.task.commons.exceptions.IllegalValueException;
+import werkbook.task.logic.commands.Command;
+import werkbook.task.logic.commands.EditCommand;
+import werkbook.task.logic.commands.IncorrectCommand;
+import werkbook.task.logic.commands.MarkCommand;
+import werkbook.task.logic.commands.MarkCommand.MarkTaskDescriptor;
+import werkbook.task.model.tag.UniqueTagList;
+
+/**
+ * Parses input arguments and creates a new MarkCommand object
+ */
+public class MarkCommandParser {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the MarkCommand
+     * and returns an MarkCommand object for execution.
+     */
+    public Command parse(String args) {
+
+        Optional<Integer> index = ParserUtil.parseIndex(args);
+        if (!index.isPresent()) {
+            return new IncorrectCommand(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+        }
+        MarkTaskDescriptor editTaskDescriptor = new MarkTaskDescriptor();
+        try {
+            ArrayList<String> newTags = new ArrayList<String>();
+            newTags.add("Complete");
+
+            editTaskDescriptor
+                    .setTags(parseTagsForEdit(ParserUtil.toSet(Optional.of(newTags))));
+        } catch (IllegalValueException ive) {
+            return new IncorrectCommand(ive.getMessage());
+        }
+
+        if (!editTaskDescriptor.isAnyFieldEdited()) {
+            return new IncorrectCommand(EditCommand.MESSAGE_NOT_EDITED);
+        }
+
+        return new MarkCommand(index.get(), editTaskDescriptor);
+    }
+
+    /**
+     * Parses {@code Collection<String> tags} into an
+     * {@code Optional<UniqueTagList>} if {@code tags} is non-empty. If
+     * {@code tags} contain only one element which is an empty string, it will
+     * be parsed into a {@code Optional<UniqueTagList>} containing zero tags.
+     */
+    private Optional<UniqueTagList> parseTagsForEdit(Collection<String> tags) throws IllegalValueException {
+        assert tags != null;
+
+        if (tags.isEmpty()) {
+            return Optional.empty();
+        }
+        Collection<String> tagSet = tags.size() == 1 && tags.contains("") ? Collections.emptySet() : tags;
+        return Optional.of(ParserUtil.parseTags(tagSet));
+    }
+
+}

--- a/src/main/java/werkbook/task/logic/parser/Parser.java
+++ b/src/main/java/werkbook/task/logic/parser/Parser.java
@@ -16,6 +16,7 @@ import werkbook.task.logic.commands.FindCommand;
 import werkbook.task.logic.commands.HelpCommand;
 import werkbook.task.logic.commands.IncorrectCommand;
 import werkbook.task.logic.commands.ListCommand;
+import werkbook.task.logic.commands.MarkCommand;
 import werkbook.task.logic.commands.RedoCommand;
 import werkbook.task.logic.commands.SelectCommand;
 import werkbook.task.logic.commands.UndoCommand;
@@ -78,6 +79,9 @@ public class Parser {
 
         case RedoCommand.COMMAND_WORD:
             return new RedoCommand();
+
+        case MarkCommand.COMMAND_WORD:
+            return new MarkCommandParser().parse(arguments);
 
         default:
             return new IncorrectCommand(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/werkbook/task/logic/parser/ParserUtil.java
+++ b/src/main/java/werkbook/task/logic/parser/ParserUtil.java
@@ -3,7 +3,7 @@ package werkbook.task.logic.parser;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -53,7 +53,7 @@ public class ParserUtil {
      */
     public static Set<String> toSet(Optional<List<String>> list) {
         List<String> elements = list.orElse(Collections.emptyList());
-        return new HashSet<>(elements);
+        return new LinkedHashSet<>(elements);
     }
 
     /**
@@ -112,7 +112,7 @@ public class ParserUtil {
      */
     public static UniqueTagList parseTags(Collection<String> tags) throws IllegalValueException {
         assert tags != null;
-        final Set<Tag> tagSet = new HashSet<>();
+        final Set<Tag> tagSet = new LinkedHashSet<>();
         for (String tagName : tags) {
             tagSet.add(new Tag(tagName));
         }

--- a/src/main/java/werkbook/task/model/TaskList.java
+++ b/src/main/java/werkbook/task/model/TaskList.java
@@ -2,7 +2,7 @@ package werkbook.task.model;
 
 import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -139,7 +139,7 @@ public class TaskList implements ReadOnlyTaskList {
 
         // Rebuild the list of task tags to point to the relevant tags in the
         // master tag list.
-        final Set<Tag> correctTagReferences = new HashSet<>();
+        final Set<Tag> correctTagReferences = new LinkedHashSet<>();
         taskTags.forEach(tag -> correctTagReferences.add(masterTagObjects.get(tag)));
         task.setTags(new UniqueTagList(correctTagReferences));
     }

--- a/src/main/java/werkbook/task/model/tag/Tag.java
+++ b/src/main/java/werkbook/task/model/tag/Tag.java
@@ -25,7 +25,7 @@ public class Tag {
         if (!isValidTagName(trimmedName)) {
             throw new IllegalValueException(MESSAGE_TAG_CONSTRAINTS);
         }
-        this.tagName = trimmedName;
+        this.tagName = toTitleCase(trimmedName);
     }
 
     /**
@@ -52,6 +52,13 @@ public class Tag {
      */
     public String toString() {
         return '[' + tagName + ']';
+    }
+
+    /**
+     * Takes in a string and returns it in title case
+     */
+    public String toTitleCase(String s) {
+        return s.substring(0, 1).toUpperCase().concat(s.substring(1));
     }
 
 }

--- a/src/main/java/werkbook/task/model/tag/UniqueTagList.java
+++ b/src/main/java/werkbook/task/model/tag/UniqueTagList.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import javafx.collections.FXCollections;
@@ -112,6 +113,18 @@ public class UniqueTagList implements Iterable<Tag> {
     public void mergeFrom(UniqueTagList from) {
         final Set<Tag> alreadyInside = this.toSet();
         from.internalList.stream().filter(tag -> !alreadyInside.contains(tag)).forEach(internalList::add);
+    }
+
+    public void mergeFromFirst(Optional<UniqueTagList> from) {
+        if (!from.isPresent()) {
+            return;
+        }
+
+        final Set<Tag> alreadyInside = this.toSet();
+        // Remove all behind first element, then add the new tags in
+        internalList.remove(1, internalList.size());
+        from.get().internalList.stream().filter(tag -> !alreadyInside.contains(tag))
+                .forEach(internalList::add);
     }
 
     /**

--- a/src/main/java/werkbook/task/model/tag/UniqueTagList.java
+++ b/src/main/java/werkbook/task/model/tag/UniqueTagList.java
@@ -3,8 +3,8 @@ package werkbook.task.model.tag;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -30,11 +30,12 @@ public class UniqueTagList implements Iterable<Tag> {
     /**
      * Constructs empty TagList.
      */
-    public UniqueTagList() {}
+    public UniqueTagList() {
+    }
 
     /**
-     * Creates a UniqueTagList using given String tags.
-     * Enforces no nulls or duplicates.
+     * Creates a UniqueTagList using given String tags. Enforces no nulls or
+     * duplicates.
      */
     public UniqueTagList(String... tags) throws DuplicateTagException, IllegalValueException {
         final List<Tag> tagList = new ArrayList<Tag>();
@@ -45,8 +46,8 @@ public class UniqueTagList implements Iterable<Tag> {
     }
 
     /**
-     * Creates a UniqueTagList using given tags.
-     * Enforces no nulls or duplicates.
+     * Creates a UniqueTagList using given tags. Enforces no nulls or
+     * duplicates.
      */
     public UniqueTagList(Tag... tags) throws DuplicateTagException {
         assert !CollectionUtil.isAnyNull((Object[]) tags);
@@ -58,8 +59,8 @@ public class UniqueTagList implements Iterable<Tag> {
     }
 
     /**
-     * Creates a UniqueTagList using given tags.
-     * Enforces no null or duplicate elements.
+     * Creates a UniqueTagList using given tags. Enforces no null or duplicate
+     * elements.
      */
     public UniqueTagList(Collection<Tag> tags) throws DuplicateTagException {
         this();
@@ -67,8 +68,7 @@ public class UniqueTagList implements Iterable<Tag> {
     }
 
     /**
-     * Creates a UniqueTagList using given tags.
-     * Enforces no nulls.
+     * Creates a UniqueTagList using given tags. Enforces no nulls.
      */
     public UniqueTagList(Set<Tag> tags) {
         assert !CollectionUtil.isAnyNull(tags);
@@ -76,19 +76,19 @@ public class UniqueTagList implements Iterable<Tag> {
     }
 
     /**
-     * Creates a copy of the given list.
-     * Insulates from changes in source.
+     * Creates a copy of the given list. Insulates from changes in source.
      */
     public UniqueTagList(UniqueTagList source) {
-        internalList.addAll(source.internalList); // insulate internal list from changes in argument
+        internalList.addAll(source.internalList); // insulate internal list from
+                                                  // changes in argument
     }
 
     /**
-     * Returns all tags in this list as a Set.
-     * This set is mutable and change-insulated against the internal list.
+     * Returns all tags in this list as a Set. This set is mutable and
+     * change-insulated against the internal list.
      */
     public Set<Tag> toSet() {
-        return new HashSet<>(internalList);
+        return new LinkedHashSet<>(internalList);
     }
 
     /**
@@ -111,13 +111,12 @@ public class UniqueTagList implements Iterable<Tag> {
      */
     public void mergeFrom(UniqueTagList from) {
         final Set<Tag> alreadyInside = this.toSet();
-        from.internalList.stream()
-                .filter(tag -> !alreadyInside.contains(tag))
-                .forEach(internalList::add);
+        from.internalList.stream().filter(tag -> !alreadyInside.contains(tag)).forEach(internalList::add);
     }
 
     /**
-     * Returns true if the list contains an equivalent Tag as the given argument.
+     * Returns true if the list contains an equivalent Tag as the given
+     * argument.
      */
     public boolean contains(Tag toCheck) {
         assert toCheck != null;
@@ -127,7 +126,8 @@ public class UniqueTagList implements Iterable<Tag> {
     /**
      * Adds a Tag to the list.
      *
-     * @throws DuplicateTagException if the Tag to add is a duplicate of an existing Tag in the list.
+     * @throws DuplicateTagException if the Tag to add is a duplicate of an
+     *             existing Tag in the list.
      */
     public void add(Tag toAdd) throws DuplicateTagException {
         assert toAdd != null;
@@ -150,12 +150,12 @@ public class UniqueTagList implements Iterable<Tag> {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof UniqueTagList // instanceof handles nulls
-                && this.internalList.equals(
-                ((UniqueTagList) other).internalList));
+                        && this.internalList.equals(((UniqueTagList) other).internalList));
     }
 
     public boolean equalsOrderInsensitive(UniqueTagList other) {
-        return this == other || new HashSet<>(this.internalList).equals(new HashSet<>(other.internalList));
+        return this == other
+                || new LinkedHashSet<>(this.internalList).equals(new LinkedHashSet<>(other.internalList));
     }
 
     @Override
@@ -164,7 +164,8 @@ public class UniqueTagList implements Iterable<Tag> {
     }
 
     /**
-     * Signals that an operation would have violated the 'no duplicates' property of the list.
+     * Signals that an operation would have violated the 'no duplicates'
+     * property of the list.
      */
     public static class DuplicateTagException extends DuplicateDataException {
         /**

--- a/src/main/java/werkbook/task/model/tag/UniqueTagList.java
+++ b/src/main/java/werkbook/task/model/tag/UniqueTagList.java
@@ -6,7 +6,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 import javafx.collections.FXCollections;
@@ -115,18 +114,6 @@ public class UniqueTagList implements Iterable<Tag> {
         from.internalList.stream().filter(tag -> !alreadyInside.contains(tag)).forEach(internalList::add);
     }
 
-    public void mergeFromFirst(Optional<UniqueTagList> from) {
-        if (!from.isPresent()) {
-            return;
-        }
-
-        final Set<Tag> alreadyInside = this.toSet();
-        // Remove all behind first element, then add the new tags in
-        internalList.remove(1, internalList.size());
-        from.get().internalList.stream().filter(tag -> !alreadyInside.contains(tag))
-                .forEach(internalList::add);
-    }
-
     /**
      * Returns true if the list contains an equivalent Tag as the given
      * argument.
@@ -157,6 +144,10 @@ public class UniqueTagList implements Iterable<Tag> {
 
     public UnmodifiableObservableList<Tag> asObservableList() {
         return new UnmodifiableObservableList<>(internalList);
+    }
+
+    public ObservableList<Tag> asModifiableObservableList() {
+        return internalList;
     }
 
     @Override

--- a/src/main/java/werkbook/task/model/task/Task.java
+++ b/src/main/java/werkbook/task/model/task/Task.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 
 import werkbook.task.commons.exceptions.IllegalValueException;
 import werkbook.task.commons.util.CollectionUtil;
+import werkbook.task.model.tag.Tag;
 import werkbook.task.model.tag.UniqueTagList;
 
 /**
@@ -111,6 +112,10 @@ public class Task implements ReadOnlyTask {
      */
     public void resetData(ReadOnlyTask replacement) {
         assert replacement != null;
+
+        for (Tag t : replacement.getTags()) {
+            System.out.println(t.toString());
+        }
 
         this.setName(replacement.getName());
         this.setDescription(replacement.getDescription());

--- a/src/main/java/werkbook/task/model/task/UniqueTaskList.java
+++ b/src/main/java/werkbook/task/model/task/UniqueTaskList.java
@@ -9,7 +9,6 @@ import werkbook.task.commons.core.UnmodifiableObservableList;
 import werkbook.task.commons.exceptions.DuplicateDataException;
 import werkbook.task.commons.exceptions.IllegalValueException;
 import werkbook.task.commons.util.CollectionUtil;
-
 /**
  * A list of tasks that enforces uniqueness between its elements and does not
  * allow nulls.

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -42,7 +42,7 @@ public class EditCommandTest extends TaskListGuiTest {
         int taskListIndex = 2;
 
         TestTask taskToEdit = expectedTaskList[taskListIndex - 1];
-        TestTask editedTask = new TaskBuilder(taskToEdit).withTags("sweetie", "bestie").build();
+        TestTask editedTask = new TaskBuilder(taskToEdit).withTags("Incomplete", "sweetie", "bestie").build();
 
         assertEditSuccess(taskListIndex, taskListIndex, detailsToEdit, editedTask);
     }
@@ -53,7 +53,7 @@ public class EditCommandTest extends TaskListGuiTest {
         int taskListIndex = 2;
 
         TestTask taskToEdit = expectedTaskList[taskListIndex - 1];
-        TestTask editedTask = new TaskBuilder(taskToEdit).withTags().build();
+        TestTask editedTask = new TaskBuilder(taskToEdit).withTags("Incomplete").build();
 
         assertEditSuccess(taskListIndex, taskListIndex, detailsToEdit, editedTask);
     }

--- a/src/test/java/guitests/MarkCommandTest.java
+++ b/src/test/java/guitests/MarkCommandTest.java
@@ -1,0 +1,107 @@
+package guitests;
+
+import static org.junit.Assert.assertTrue;
+import static werkbook.task.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import org.junit.Test;
+
+import guitests.guihandles.TaskCardHandle;
+import werkbook.task.commons.core.Messages;
+import werkbook.task.logic.commands.MarkCommand;
+import werkbook.task.testutil.TaskBuilder;
+import werkbook.task.testutil.TestTask;
+
+// TODO: reduce GUI tests by transferring some tests to be covered by lower level tests.
+public class MarkCommandTest extends TaskListGuiTest {
+
+    // The list of tasks in the task list panel is expected to match this
+    // list.
+    // This list is updated with every successful call to assertEditSuccess().
+    TestTask[] expectedTaskList = td.getTypicalTasks();
+
+    @Test
+    public void mark_task_success() throws Exception {
+        int taskListIndex = 1;
+
+        TestTask markedTask = new TaskBuilder().withName("Walk the dog")
+                .withDescription("Take Zelda on a walk at the park").withStartDateTime("01/01/2016 0900")
+                .withEndDateTime("01/01/2016 1000").withTags("Complete").build();
+
+        assertMarkSuccess(taskListIndex, taskListIndex, markedTask, true);
+    }
+
+    @Test
+    public void unmark_task_success() throws Exception {
+        int taskListIndex = 1;
+
+        TestTask markedTask = new TaskBuilder().withName("Walk the dog")
+                .withDescription("Take Zelda on a walk at the park").withStartDateTime("01/01/2016 0900")
+                .withEndDateTime("01/01/2016 1000").withTags("Complete").build();
+
+        assertMarkSuccess(taskListIndex, taskListIndex, markedTask, true);
+
+        // Now mark again, Complete should revert back to incomplete
+        markedTask = new TaskBuilder().withName("Walk the dog")
+                .withDescription("Take Zelda on a walk at the park").withStartDateTime("01/01/2016 0900")
+                .withEndDateTime("01/01/2016 1000").withTags("Incomplete").build();
+
+        assertMarkSuccess(taskListIndex, taskListIndex, markedTask, false);
+    }
+
+    @Test
+    public void mark_findThenMark_success() throws Exception {
+        commandBox.runCommand("find fish");
+
+        int filteredTaskListIndex = 1;
+        int taskListIndex = 5;
+
+        TestTask taskToEdit = expectedTaskList[taskListIndex - 1];
+        TestTask editedTask = new TaskBuilder(taskToEdit).withName("Walk the fish")
+                .withDescription("Take Zelda on a walk at the park").withStartDateTime("01/01/2016 0900")
+                .withEndDateTime("01/01/2016 1000").withTags("Incomplete").build();
+
+        assertMarkSuccess(filteredTaskListIndex, taskListIndex, editedTask, false);
+    }
+
+    @Test
+    public void mark_invalidCommand_failure() {
+        commandBox.runCommand("mark This task");
+        assertResultMessage(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MarkCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void mark_invalidTaskIndex_failure() {
+        commandBox.runCommand("mark 20");
+        assertResultMessage(Messages.MESSAGE_INVALID_TASK_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Checks whether the marked task has the correct updated status.
+     *
+     * @param filteredTaskListIndex index of task to mark in filtered list
+     * @param taskListIndex index of task to mark in the task list. Must refer
+     *            to the same task as {@code filteredTaskListIndex}
+     * @param detailsToEdit details to mark the task with as input to the edit
+     *            command
+     * @param markedTask the expected task after editing the task's details
+     */
+    private void assertMarkSuccess(int filteredTaskListIndex, int taskListIndex, TestTask markedTask,
+            boolean hasMarked) {
+        commandBox.runCommand("mark " + filteredTaskListIndex);
+
+        // confirm the new card contains the right data
+        TaskCardHandle existingTask = taskListPanel.navigateToTask(markedTask.getName().toString());
+        assertMatching(markedTask, existingTask);
+
+        // confirm the list now contains all previous tasks plus the task
+        // with updated details
+        expectedTaskList[taskListIndex - 1] = markedTask;
+        assertTrue(taskListPanel.isListMatching(expectedTaskList));
+
+        if (hasMarked) {
+            assertResultMessage(String.format(MarkCommand.MESSAGE_MARK_TASK_SUCCESS, markedTask.getName()));
+        } else {
+            assertResultMessage(String.format(MarkCommand.MESSAGE_UNMARK_TASK_SUCCESS, markedTask.getName()));
+        }
+    }
+}

--- a/src/test/java/guitests/guihandles/TaskCardHandle.java
+++ b/src/test/java/guitests/guihandles/TaskCardHandle.java
@@ -66,6 +66,8 @@ public class TaskCardHandle extends GuiHandle {
     }
 
     public boolean isSameTask(ReadOnlyTask task) {
+        System.out.println(getTags().equals(getTags(task.getTags())));
+
         return getFullName().equals(task.getName().toString())
                 && getDescription().equals(task.getDescription().toString())
                 && getEndDateTime().equals(task.getEndDateTime().toString())

--- a/src/test/java/guitests/guihandles/TaskCardHandle.java
+++ b/src/test/java/guitests/guihandles/TaskCardHandle.java
@@ -66,8 +66,6 @@ public class TaskCardHandle extends GuiHandle {
     }
 
     public boolean isSameTask(ReadOnlyTask task) {
-        System.out.println(getTags().equals(getTags(task.getTags())));
-
         return getFullName().equals(task.getName().toString())
                 && getDescription().equals(task.getDescription().toString())
                 && getEndDateTime().equals(task.getEndDateTime().toString())

--- a/src/test/java/werkbook/task/logic/LogicManagerTest.java
+++ b/src/test/java/werkbook/task/logic/LogicManagerTest.java
@@ -443,20 +443,6 @@ public class LogicManagerTest {
         assertCommandSuccess("undo", UndoCommand.MESSAGE_SUCCESS, expectedTaskList, expectedTaskList.getTaskList());
     }
 
-    @Test
-    public void execute_mark_tagShowsOpposite() throws Exception {
-        TestDataHelper helper = new TestDataHelper();
-        Task toBeAdded = helper.adam();
-        TaskList expectedTaskList = new TaskList();
-        expectedTaskList.addTask(toBeAdded);
-
-        // execute command and verify result
-        assertCommandSuccess(helper.generateAddCommand(toBeAdded),
-                String.format(AddCommand.MESSAGE_SUCCESS, toBeAdded),
-                expectedTaskList,
-                expectedTaskList.getTaskList());
-    }
-
     /**
      * A utility class to generate test data.
      */
@@ -482,7 +468,7 @@ public class LogicManagerTest {
         Task generateTask(int seed) throws Exception {
             return new Task(new Name("Task " + seed), new Description("" + Math.abs(seed)),
                     new StartDateTime("01/01/2016 0900"), new EndDateTime("02/01/2016 1000"),
-                    new UniqueTagList());
+                    new UniqueTagList("Incomplete"));
         }
 
         /** Generates the correct add command based on the task given */

--- a/src/test/java/werkbook/task/logic/LogicManagerTest.java
+++ b/src/test/java/werkbook/task/logic/LogicManagerTest.java
@@ -443,6 +443,20 @@ public class LogicManagerTest {
         assertCommandSuccess("undo", UndoCommand.MESSAGE_SUCCESS, expectedTaskList, expectedTaskList.getTaskList());
     }
 
+    @Test
+    public void execute_mark_tagShowsOpposite() throws Exception {
+        TestDataHelper helper = new TestDataHelper();
+        Task toBeAdded = helper.adam();
+        TaskList expectedTaskList = new TaskList();
+        expectedTaskList.addTask(toBeAdded);
+
+        // execute command and verify result
+        assertCommandSuccess(helper.generateAddCommand(toBeAdded),
+                String.format(AddCommand.MESSAGE_SUCCESS, toBeAdded),
+                expectedTaskList,
+                expectedTaskList.getTaskList());
+    }
+
     /**
      * A utility class to generate test data.
      */
@@ -453,9 +467,8 @@ public class LogicManagerTest {
             Description description = new Description("By lunch time");
             StartDateTime startDateTime = new StartDateTime("01/01/1980 0000");
             EndDateTime endDateTime = new EndDateTime("01/01/1980 0500");
-            Tag tag1 = new Tag("tag1");
-            Tag tag2 = new Tag("longertag2");
-            UniqueTagList tags = new UniqueTagList(tag1, tag2);
+            Tag tag1 = new Tag("Incomplete");
+            UniqueTagList tags = new UniqueTagList(tag1);
             return new Task(name, description, startDateTime, endDateTime, tags);
         }
 
@@ -469,7 +482,7 @@ public class LogicManagerTest {
         Task generateTask(int seed) throws Exception {
             return new Task(new Name("Task " + seed), new Description("" + Math.abs(seed)),
                     new StartDateTime("01/01/2016 0900"), new EndDateTime("02/01/2016 1000"),
-                    new UniqueTagList(new Tag("tag" + Math.abs(seed)), new Tag("tag" + Math.abs(seed + 1))));
+                    new UniqueTagList());
         }
 
         /** Generates the correct add command based on the task given */
@@ -566,7 +579,7 @@ public class LogicManagerTest {
          */
         Task generateTaskWithName(String name) throws Exception {
             return new Task(new Name(name), new Description("1"), new StartDateTime("01/01/1980 0000"),
-                    new EndDateTime("01/01/1980 0100"), new UniqueTagList(new Tag("tag")));
+                    new EndDateTime("01/01/1980 0100"), new UniqueTagList());
         }
     }
 }

--- a/src/test/java/werkbook/task/testutil/TypicalTestTasks.java
+++ b/src/test/java/werkbook/task/testutil/TypicalTestTasks.java
@@ -39,10 +39,10 @@ public class TypicalTestTasks {
             // Manually added
             hoon = new TaskBuilder().withName("Walk the tiger")
                     .withDescription("Take Zelda on a walk at the park").withStartDateTime("01/01/2016 0900")
-                    .withEndDateTime("01/01/2016 1000").build();
+                    .withEndDateTime("01/01/2016 1000").withTags("Incomplete").build();
             ida = new TaskBuilder().withName("Walk the zebra")
                     .withDescription("Take Zelda on a walk at the park").withStartDateTime("01/01/2016 0900")
-                    .withEndDateTime("01/01/2016 1000").build();
+                    .withEndDateTime("01/01/2016 1000").withTags("Incomplete").build();
         } catch (IllegalValueException e) {
             e.printStackTrace();
             assert false : "not possible";


### PR DESCRIPTION
Fixes #46 #67 

Add new Mark command to modify the status of a task
A task can have two statuses: Complete, Incomplete
A default "Incomplete" status tag will be maintained as the first tag of every task
Using the command will change to status from "Incomplete" to "Complete" and vice-versa
All other tags will be maintained behind the status tag
Tags now default to title case 

TO DO:
Update documentation