### PR TITLE
Change description prefix and suffix to "(" and ")"

### DIFF
--- a/src/main/java/werkbook/task/logic/commands/AddCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/AddCommand.java
@@ -25,9 +25,9 @@ public class AddCommand extends Command {
             + "The task must have a task name, description is optional.\n"
             + "The task can optionally have an end date and time "
             + "but is required if it also has a start date and time.\n"
-            + "Parameters: Task name [d/Description] [from Start date and time] [to End date and time]  [t/Tag]...\n"
+            + "Parameters: Task name [(Description)] [from Start date and time] [to End date and time]  [t/Tag]...\n"
             + "Example: " + COMMAND_WORD
-            + " Walk the dog d/Take Zelda on a walk around the park from 01/01/2017 1000 to 01/01/2017"
+            + " Walk the dog (Take Zelda on a walk around the park) from 01/01/2017 1000 to 01/01/2017"
             + " 1200 t/Important";
 
     public static final String MESSAGE_SUCCESS = "New task added: %1$s";

--- a/src/main/java/werkbook/task/logic/commands/EditCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/EditCommand.java
@@ -27,9 +27,9 @@ public class EditCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the task identified "
             + "by the index number used in the last task listing. "
             + "Existing values will be overwritten by the input values.\n"
-            + "Parameters: INDEX (must be a positive integer) [NAME] [d/Description]"
+            + "Parameters: INDEX (must be a positive integer) [NAME] [(Description)]"
             + "[from Start date and time] [to End date and time] [t/Tag]...\n" + "Example: " + COMMAND_WORD
-            + " 1 d/Walk the dog to 08/03/2017 0300";
+            + " 1 (Walk the dog) to 08/03/2017 0300";
 
     public static final String MESSAGE_EDIT_TASK_SUCCESS = "Edited task: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";

--- a/src/main/java/werkbook/task/logic/parser/AddCommandParser.java
+++ b/src/main/java/werkbook/task/logic/parser/AddCommandParser.java
@@ -3,6 +3,7 @@ package werkbook.task.logic.parser;
 import static werkbook.task.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static werkbook.task.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static werkbook.task.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static werkbook.task.logic.parser.CliSyntax.PREFIX_DESCRIPTIONEND;
 import static werkbook.task.logic.parser.CliSyntax.PREFIX_ENDDATETIME;
 import static werkbook.task.logic.parser.CliSyntax.PREFIX_STARTDATETIME;
 import static werkbook.task.logic.parser.CliSyntax.PREFIX_TAG;
@@ -25,8 +26,8 @@ public class AddCommandParser {
      * AddCommand and returns an AddCommand object for execution.
      */
     public Command parse(String args) {
-        ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(PREFIX_DESCRIPTION, PREFIX_STARTDATETIME,
-                PREFIX_ENDDATETIME, PREFIX_DEADLINE, PREFIX_TAG);
+        ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(PREFIX_DESCRIPTION, PREFIX_DESCRIPTIONEND,
+                PREFIX_STARTDATETIME, PREFIX_ENDDATETIME, PREFIX_DEADLINE, PREFIX_TAG);
         try {
             argsTokenizer.tokenize(args);
 

--- a/src/main/java/werkbook/task/logic/parser/CliSyntax.java
+++ b/src/main/java/werkbook/task/logic/parser/CliSyntax.java
@@ -11,7 +11,8 @@ public class CliSyntax {
 
     //@@author A0139903B
     /* Prefix definitions */
-    public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
+    public static final Prefix PREFIX_DESCRIPTION = new Prefix("(");
+    public static final Prefix PREFIX_DESCRIPTIONEND = new Prefix(")");
     public static final Prefix PREFIX_STARTDATETIME = new Prefix("from", true);
     public static final Prefix PREFIX_ENDDATETIME = new Prefix("to", true);
     public static final Prefix PREFIX_DEADLINE = new Prefix("by", true);

--- a/src/main/java/werkbook/task/logic/parser/EditCommandParser.java
+++ b/src/main/java/werkbook/task/logic/parser/EditCommandParser.java
@@ -3,6 +3,7 @@ package werkbook.task.logic.parser;
 import static werkbook.task.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static werkbook.task.logic.parser.CliSyntax.PREFIX_DEADLINE;
 import static werkbook.task.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static werkbook.task.logic.parser.CliSyntax.PREFIX_DESCRIPTIONEND;
 import static werkbook.task.logic.parser.CliSyntax.PREFIX_ENDDATETIME;
 import static werkbook.task.logic.parser.CliSyntax.PREFIX_STARTDATETIME;
 import static werkbook.task.logic.parser.CliSyntax.PREFIX_TAG;
@@ -30,8 +31,8 @@ public class EditCommandParser {
      */
     public Command parse(String args) {
         assert args != null;
-        ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(PREFIX_DESCRIPTION, PREFIX_STARTDATETIME,
-                PREFIX_ENDDATETIME, PREFIX_DEADLINE, PREFIX_TAG);
+        ArgumentTokenizer argsTokenizer = new ArgumentTokenizer(PREFIX_DESCRIPTION, PREFIX_DESCRIPTIONEND,
+                PREFIX_STARTDATETIME, PREFIX_ENDDATETIME, PREFIX_DEADLINE, PREFIX_TAG);
         try {
             argsTokenizer.tokenize(args);
         } catch (IllegalValueException ive) {

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -24,7 +24,7 @@ public class EditCommandTest extends TaskListGuiTest {
 
     @Test
     public void edit_allFieldsSpecified_success() throws Exception {
-        String detailsToEdit = "Walk the dog d/Take Zelda on a walk around the park "
+        String detailsToEdit = "Walk the dog(Take Zelda on a walk around the park) "
                 + "from 01/01/2016 0900 to 01/01/2016 1000 t/Incomplete";
         int taskListIndex = 1;
 
@@ -108,7 +108,7 @@ public class EditCommandTest extends TaskListGuiTest {
 
     @Test
     public void edit_duplicateTask_failure() {
-        commandBox.runCommand("edit 3 Walk the dog d/Take Zelda on a walk at the park"
+        commandBox.runCommand("edit 3 Walk the dog (Take Zelda on a walk at the park)"
                 + "from 01/01/2016 0900 to 01/01/2016 1000 t/Important");
     }
 

--- a/src/test/java/werkbook/task/logic/LogicManagerTest.java
+++ b/src/test/java/werkbook/task/logic/LogicManagerTest.java
@@ -214,19 +214,19 @@ public class LogicManagerTest {
 
     @Test
     public void execute_add_invalidTaskData() {
-        assertCommandFailure("add []\\[;] d/12345 from 01/01/1980 0000 to 01/01/1980 0100",
+        assertCommandFailure("add []\\[;] (12345) from 01/01/1980 0000 to 01/01/1980 0100",
                 Name.MESSAGE_NAME_CONSTRAINTS);
         // To fix
         //assertCommandFailure("add Valid Name d/12345 from 99/99/9999 9999 to 01/01/1980 1000",
         //        StartDateTime.MESSAGE_START_DATETIME_CONSTRAINTS);
         assertCommandFailure(
-                "add Valid Name d/12345 from 01/01/1980 0000 to 01/01/1980 0100 t/invalid_-[.tag",
+                "add Valid Name (12345) from 01/01/1980 0000 to 01/01/1980 0100 t/invalid_-[.tag",
                 Tag.MESSAGE_TAG_CONSTRAINTS);
         assertCommandFailure(
-                "add Valid Name d/12345 from 01/01/1980 0000",
+                "add Valid Name (12345) from 01/01/1980 0000",
                 Task.MESSAGE_START_WITHOUT_END_CONSTRAINTS);
         assertCommandFailure(
-                "add Valid Name d/12345 from 01/01/1980 0000 to 01/01/1979 0000",
+                "add Valid Name (12345) from 01/01/1980 0000 to 01/01/1979 0000",
                 Task.MESSAGE_END_BEFORE_START_CONSTRAINTS);
 
     }
@@ -486,7 +486,7 @@ public class LogicManagerTest {
             cmd.append("add ");
 
             cmd.append(p.getName().toString());
-            cmd.append(" d/").append(p.getDescription().toString());
+            cmd.append(" (").append(p.getDescription().toString()).append(") ");
             cmd.append(" from ").append(p.getStartDateTime().toString());
             cmd.append(" to ").append(p.getEndDateTime().toString());
 

--- a/src/test/java/werkbook/task/testutil/TestTask.java
+++ b/src/test/java/werkbook/task/testutil/TestTask.java
@@ -86,8 +86,8 @@ public class TestTask implements ReadOnlyTask {
     public String getAddCommand() {
         StringBuilder sb = new StringBuilder();
         sb.append("add " + this.getName().taskName + " ");
-        sb.append("d/" + this.getDescription().toString() + " ");
-        sb.append("from" + this.getStartDateTime().toString() + " ");
+        sb.append("(" + this.getDescription().toString() + ") ");
+        sb.append("from " + this.getStartDateTime().toString() + " ");
         sb.append("to " + this.getEndDateTime().toString() + " ");
         this.getTags().asObservableList().stream().forEach(s -> sb.append("t/" + s.tagName + " "));
         return sb.toString();


### PR DESCRIPTION
Fixes #111 
Description prefix is now changed to "(" and ")"
Examples that work:
> add Task name (description) by 5pm

Creates a new task with "Task name" as the name, "description" as description, and 5pm as deadline

> add Task name (description from 5pm to 10pm) from 5pm to 10pm 

Creates a new task with "Task name" as the name, "description from 5pm to 10pm" as description, and 5pm and 10pm as the start and end time

Examples that don't work (No error messages here to provide "flexibility" for users): 
> add Task name (description

Creates a new task with "Task name (description" as the name

> add Task name )description

Creates a new task with "Task name )description" as the name

> add Task name )description( 

Creates a new task with "Task name )description(