### PR TITLE
Switch to natty for NLP for date times

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ allprojects {
         googleAPITasks = 'v1-rev46-1.22.0'
         prettytimeNLPVersion = '4.0.0.Final'
         prettytimeVersion = '4.0.0.Final'
+        nattyVersion = '0.13'
 
         libDir = 'lib'
     }
@@ -72,7 +73,7 @@ allprojects {
         compile "com.google.oauth-client:google-oauth-client-jetty:$googleOAuthClient"
         compile "com.google.apis:google-api-services-tasks:$googleAPITasks"
         compile "org.ocpsoft.prettytime:prettytime:$prettytimeVersion"
-        compile "org.ocpsoft.prettytime:prettytime-nlp:$prettytimeNLPVersion"
+        compile "com.joestelmach:natty:$nattyVersion"
 
         testCompile "junit:junit:$junitVersion"
         testCompile "org.testfx:testfx-core:$testFxVersion"

--- a/src/main/java/werkbook/task/logic/parser/CliSyntax.java
+++ b/src/main/java/werkbook/task/logic/parser/CliSyntax.java
@@ -13,9 +13,9 @@ public class CliSyntax {
     /* Prefix definitions */
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("(");
     public static final Prefix PREFIX_DESCRIPTIONEND = new Prefix(")");
-    public static final Prefix PREFIX_STARTDATETIME = new Prefix("from", true);
-    public static final Prefix PREFIX_ENDDATETIME = new Prefix("to", true);
-    public static final Prefix PREFIX_DEADLINE = new Prefix("by", true);
+    public static final Prefix PREFIX_STARTDATETIME = new Prefix(" from ", true);
+    public static final Prefix PREFIX_ENDDATETIME = new Prefix(" to ", true);
+    public static final Prefix PREFIX_DEADLINE = new Prefix(" by ", true);
     //@author
 
     /* Patterns definitions */

--- a/src/main/java/werkbook/task/logic/parser/DateTimeParser.java
+++ b/src/main/java/werkbook/task/logic/parser/DateTimeParser.java
@@ -1,7 +1,6 @@
 package werkbook.task.logic.parser;
 
 import java.util.Date;
-import java.util.List;
 
 import werkbook.task.model.util.DateTimeUtil;
 
@@ -15,9 +14,9 @@ public class DateTimeParser {
      * @param date Any string to be parsed
      * @return Returns formatted date time if a string was found, an empty string otherwise
      */
-    public static String parse(String date) {
-        List<Date> dateList = DateTimeUtil.parse(date);
-        return dateList.size() == 0 ? "" : DateTimeUtil.DATETIME_FORMATTER.format(dateList.get(0));
+    public static String parse(String dateToParse) {
+        Date date = DateTimeUtil.parse(dateToParse);
+        return date == null ? "" : DateTimeUtil.DATETIME_FORMATTER.format(date);
     }
 
     /**
@@ -25,9 +24,8 @@ public class DateTimeParser {
      * @param date Any string to be parsed
      * @return Returns a Date if a date was found, an empty object otherwise
      */
-    public static Date parseAsDate(String date) {
-        List<Date> dateList = DateTimeUtil.parse(date);
-        return dateList.size() == 0 ? null : dateList.get(0);
+    public static Date parseAsDate(String dateToParse) {
+        return DateTimeUtil.parse(dateToParse);
     }
 
     /**
@@ -36,6 +34,6 @@ public class DateTimeParser {
      * @return Returns true if the date is valid
      */
     public static boolean isValidDate(String date) {
-        return DateTimeUtil.parse(date).size() != 0 ? true : false;
+        return DateTimeUtil.parse(date) != null;
     }
 }

--- a/src/main/java/werkbook/task/model/util/DateTimeUtil.java
+++ b/src/main/java/werkbook/task/model/util/DateTimeUtil.java
@@ -6,7 +6,9 @@ import java.util.List;
 import java.util.Locale;
 
 import org.ocpsoft.prettytime.PrettyTime;
-import org.ocpsoft.prettytime.nlp.PrettyTimeParser;
+
+import com.joestelmach.natty.DateGroup;
+import com.joestelmach.natty.Parser;
 
 //@@author A0139903B
 /**
@@ -18,16 +20,21 @@ public class DateTimeUtil {
     public static final SimpleDateFormat DATETIME_FORMATTER = new SimpleDateFormat("dd/MM/yyyy HHmm");
 
     private static PrettyTime prettyTime = new PrettyTime(Locale.UK);
-    private static PrettyTimeParser prettyTimeParser = new PrettyTimeParser();
+    private static Parser nattyParser = new Parser();
     private static Date currentDate = new Date();
 
     /**
-     * Parses a string and extracts any values with resemblance to a date using PrettyTimeNLP
+     * Parses a string and extracts any values with resemblance to a date using natty time
      * @param dateToParse a string to be parsed
-     * @return a list of dates found in the string
+     * @return Date found in the string
      */
-    public static List<Date> parse(String dateToParse) {
-        return prettyTimeParser.parse(dateToParse);
+    public static Date parse(String dateToParse) {
+        List<DateGroup> groups = nattyParser.parse(dateToParse);
+        Date date = null;
+        for (DateGroup group: groups) {
+            date = group.getDates().get(0);
+        }
+        return date;
     }
 
     /**
@@ -39,10 +46,6 @@ public class DateTimeUtil {
     public static String getPrettyDateTime(Date date) {
         return getDifferenceInDays(date, currentDate) > NUM_OF_DAYS_LIMIT ? DATETIME_FORMATTER.format(date)
                 : prettyTime.format(date);
-    }
-
-    public static Date getVerboseDateTime(String dateToParse) {
-        return prettyTimeParser.parse(dateToParse).get(0);
     }
 
     /**


### PR DESCRIPTION
Fix concat in date time

Relative dates such as "today" and "tomorrow" now works
Words containing "to" substrings like "refrigerator" don't get an extra spacing behind the "to"