### PR TITLE
Fix list view

### DIFF
--- a/src/main/java/werkbook/task/logic/commands/EditCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/EditCommand.java
@@ -78,7 +78,7 @@ public class EditCommand extends Command {
             throw new CommandException(MESSAGE_DUPLICATE_TASK);
         }
 
-        model.updateFilteredListToShowAll();
+        model.updateFilteredList();
 
         int updatedIndex = model.getFilteredTaskList().indexOf(taskToEdit);
 

--- a/src/main/java/werkbook/task/logic/commands/ListCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/ListCommand.java
@@ -13,7 +13,7 @@ public class ListCommand extends Command {
     public static final String MESSAGE_SHOW_COMPLETE_SUCCESS = "(ﾉ´ヮ`)ﾉ*: ･ﾟ"
             + "\nThese are your completed tasks!";
     public static final String MESSAGE_SHOW_INCOMPLETE_SUCCESS = "(っ´ω`)ﾉ(╥ω╥)"
-            + "\nThese are your uncompleted tasks!";
+            + "\nThese are your incomplete tasks!";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Lists tasks by completion status, lists all tasks by default\n"

--- a/src/main/java/werkbook/task/logic/commands/MarkCommand.java
+++ b/src/main/java/werkbook/task/logic/commands/MarkCommand.java
@@ -90,7 +90,7 @@ public class MarkCommand extends Command {
             dpe.printStackTrace();
         }
 
-        model.updateFilteredListToShowAll();
+        model.updateFilteredList();
         EventsCenter.getInstance().post(new JumpToListRequestEvent(targetIndex));
 
         return new CommandResult(String.format(statusMessage, taskToMark.getName()));

--- a/src/main/java/werkbook/task/model/Model.java
+++ b/src/main/java/werkbook/task/model/Model.java
@@ -50,6 +50,9 @@ public interface Model {
      */
     UnmodifiableObservableList<ReadOnlyTask> getFilteredTaskList();
 
+    /** Updates the current filtered task list */
+    void updateFilteredList();
+
     /** Updates the filter of the filtered task list to show all tasks */
     void updateFilteredListToShowAll();
 
@@ -60,14 +63,12 @@ public interface Model {
     void updateFilteredTaskList(Set<String> keywords);
 
     /**
-     * Updates the filter of the filtered task list to filter by the given
-     * keywords
+     * Updates the filter of the filtered task list to filter by incomplete status
      */
     void updateFilteredTaskListToShowIncomplete();
 
     /**
-     * Updates the filter of the filtered task list to filter by the given
-     * keywords
+     * Updates the filter of the filtered task list to filter by complete status
      */
     void updateFilteredTaskListToShowComplete();
 

--- a/src/main/java/werkbook/task/model/ModelManager.java
+++ b/src/main/java/werkbook/task/model/ModelManager.java
@@ -31,6 +31,16 @@ public class ModelManager extends ComponentManager implements Model {
     private final FilteredList<ReadOnlyTask> filteredTasks;
     private static Stack<TaskList> undoStack, redoStack;
 
+    private enum LISTSTATUS {
+        ALL,
+        COMPLETE,
+        INCOMPLETE,
+        SEARCH
+    };
+
+    private LISTSTATUS listStatus;
+    private Set<String> lastSearchedKeywords;
+
     /**
      * Initializes a ModelManager with the given taskList and userPrefs.
      */
@@ -44,6 +54,7 @@ public class ModelManager extends ComponentManager implements Model {
         filteredTasks = new FilteredList<>(this.taskList.getTaskList());
         undoStack = new Stack<TaskList>();
         redoStack = new Stack<TaskList>();
+        listStatus = LISTSTATUS.ALL;
     }
 
     public ModelManager() {
@@ -149,12 +160,35 @@ public class ModelManager extends ComponentManager implements Model {
     }
 
     @Override
+    public void updateFilteredList() {
+        switch(listStatus) {
+        case ALL:
+            updateFilteredListToShowAll();
+            break;
+        case COMPLETE:
+            updateFilteredTaskListToShowComplete();
+            break;
+        case INCOMPLETE:
+            updateFilteredTaskListToShowIncomplete();
+            break;
+        case SEARCH:
+            updateFilteredTaskList(lastSearchedKeywords);
+            break;
+        default:
+            break;
+        }
+    }
+
+    @Override
     public void updateFilteredListToShowAll() {
+        listStatus = LISTSTATUS.ALL;
         filteredTasks.setPredicate(null);
     }
 
     @Override
     public void updateFilteredTaskList(Set<String> keywords) {
+        listStatus = LISTSTATUS.SEARCH;
+        lastSearchedKeywords = keywords;
         updateFilteredTaskList(new PredicateExpression(new NameQualifier(keywords)));
     }
 
@@ -166,6 +200,7 @@ public class ModelManager extends ComponentManager implements Model {
     public void updateFilteredTaskListToShowIncomplete() {
         Set<String> keywords = new HashSet<String>();
         keywords.add("Incomplete");
+        listStatus = LISTSTATUS.INCOMPLETE;
         updateFilteredTaskList(new PredicateExpression(new StatusQualifier(keywords)));
     }
 
@@ -173,6 +208,7 @@ public class ModelManager extends ComponentManager implements Model {
     public void updateFilteredTaskListToShowComplete() {
         Set<String> keywords = new HashSet<String>();
         keywords.add("Complete");
+        listStatus = LISTSTATUS.COMPLETE;
         updateFilteredTaskList(new PredicateExpression(new StatusQualifier(keywords)));
     }
 

--- a/src/main/java/werkbook/task/model/task/Name.java
+++ b/src/main/java/werkbook/task/model/task/Name.java
@@ -15,7 +15,7 @@ public class Name {
      * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String NAME_VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*.+";
+    public static final String NAME_VALIDATION_REGEX = "[\\p{Alnum}]*.+";
 
     public final String taskName;
 

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -93,8 +93,8 @@ public class EditCommandTest extends TaskListGuiTest {
 
     @Test
     public void edit_invalidValues_failure() {
-        commandBox.runCommand("edit 1 *&");
-        assertResultMessage(Name.MESSAGE_NAME_CONSTRAINTS);
+        commandBox.runCommand("edit 1 ");
+        assertResultMessage(EditCommand.MESSAGE_NOT_EDITED);
 
         // commandBox.runCommand("edit 1 d/abcd");
         // assertResultMessage(Description.MESSAGE_DESCRIPTION_CONSTRAINTS);
@@ -124,6 +124,9 @@ public class EditCommandTest extends TaskListGuiTest {
             TestTask editedTask) {
         commandBox.runCommand("edit " + filteredTaskListIndex + " " + detailsToEdit);
 
+        assertResultMessage(String.format(EditCommand.MESSAGE_EDIT_TASK_SUCCESS, editedTask));
+        commandBox.runCommand("list");
+
         // confirm the new card contains the right data
         TaskCardHandle editedCard = taskListPanel.navigateToTask(editedTask.getName().toString());
         assertMatching(editedTask, editedCard);
@@ -132,6 +135,5 @@ public class EditCommandTest extends TaskListGuiTest {
         // with updated details
         expectedTaskList[taskListIndex - 1] = editedTask;
         assertTrue(taskListPanel.isListMatching(expectedTaskList));
-        assertResultMessage(String.format(EditCommand.MESSAGE_EDIT_TASK_SUCCESS, editedTask));
     }
 }

--- a/src/test/java/guitests/EditCommandTest.java
+++ b/src/test/java/guitests/EditCommandTest.java
@@ -8,8 +8,6 @@ import org.junit.Test;
 import guitests.guihandles.TaskCardHandle;
 import werkbook.task.commons.core.Messages;
 import werkbook.task.logic.commands.EditCommand;
-import werkbook.task.model.task.Name;
-// import werkbook.task.model.task.StartDateTime;
 import werkbook.task.testutil.TaskBuilder;
 import werkbook.task.testutil.TestTask;
 

--- a/src/test/java/guitests/MarkCommandTest.java
+++ b/src/test/java/guitests/MarkCommandTest.java
@@ -95,15 +95,16 @@ public class MarkCommandTest extends TaskListGuiTest {
 
         assertMatching(markedTask, existingTask);
 
-        // confirm the list now contains all previous tasks plus the task
-        // with updated details
-        expectedTaskList[taskListIndex - 1] = markedTask;
-        assertTrue(taskListPanel.isListMatching(expectedTaskList));
-
         if (hasMarked) {
             assertResultMessage(String.format(MarkCommand.MESSAGE_MARK_TASK_SUCCESS, markedTask.getName()));
         } else {
             assertResultMessage(String.format(MarkCommand.MESSAGE_UNMARK_TASK_SUCCESS, markedTask.getName()));
         }
+
+        // confirm the list now contains all previous tasks plus the task
+        // with updated details
+        expectedTaskList[taskListIndex - 1] = markedTask;
+        commandBox.runCommand("list");
+        assertTrue(taskListPanel.isListMatching(expectedTaskList));
     }
 }

--- a/src/test/java/werkbook/task/logic/LogicManagerTest.java
+++ b/src/test/java/werkbook/task/logic/LogicManagerTest.java
@@ -220,11 +220,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_add_invalidTaskData() {
-        assertCommandFailure("add []\\[;] (12345) from 01/01/1980 0000 to 01/01/1980 0100",
+        assertCommandFailure("add (12345) from 01/01/1980 0000 to 01/01/1980 0100",
                 Name.MESSAGE_NAME_CONSTRAINTS);
-        // To fix
-        //assertCommandFailure("add Valid Name d/12345 from 99/99/9999 9999 to 01/01/1980 1000",
-        //        StartDateTime.MESSAGE_START_DATETIME_CONSTRAINTS);
         assertCommandFailure(
                 "add Valid Name (12345) from 01/01/1980 0000",
                 Task.MESSAGE_START_WITHOUT_END_CONSTRAINTS);


### PR DESCRIPTION
Current state of the list will be preserved on commands.
Example:
`list incomplete`
`mark 1`

The list of incomplete tasks will show up, after executing `mark 1`, the list will still show incomplete tasks.